### PR TITLE
Block update method added because I'm not a fan of delegates.

### DIFF
--- a/MGWordCounterDemo/MGWordCounter.h
+++ b/MGWordCounterDemo/MGWordCounter.h
@@ -61,6 +61,7 @@
 - (void)updateCount; // Updates count immediately, via full recount. You shouldn't need to call this; updates happen automatically.
 
 @property (nonatomic, weak) id <MGWordCounterDelegate> delegate; // Delegate for this object.
+@property (nonatomic, copy) void (^counterUpdateBlock)(NSInteger, BOOL); // Block object called during update
 #if TARGET_OS_IPHONE
 @property (nonatomic, strong) UITextView *textView; // This counter's associated text-view.
 #else

--- a/MGWordCounterDemo/MGWordCounter.m
+++ b/MGWordCounterDemo/MGWordCounter.m
@@ -217,8 +217,9 @@ NSString *MGWordCounterDidUpdateWordCountNotification = @"MGWordCounterDidUpdate
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object
                         change:(NSDictionary *)change context:(void *)context
 {
-    // We're Key-Value Observing changes to the OPERATION_FINISHED_KEY key-path of each operation.
-    // When an operation finishes, this method is called.
+    // We're Key-Value Observing changes to the QUEUE_COUNT_KEY key-path of our operationQueue.
+    // When the number of operations in the queue changes, this method is called.
+    // Operation Queues remove completed operations, hence this means the operation finished.
     
     MGWordCountOperation *countOperation = (MGWordCountOperation *)object;
     if (object && [keyPath isEqualToString:OPERATION_FINISHED_KEY]) {
@@ -249,6 +250,13 @@ NSString *MGWordCounterDidUpdateWordCountNotification = @"MGWordCounterDidUpdate
                             });
                         }
                         
+                        //Update Block
+                        
+                        if (self.counterUpdateBlock)
+                        {
+                            self.counterUpdateBlock(_wordCount,selectionCount);
+                        }
+                        
                         // Send notification.
                         NSDictionary *info = [NSDictionary dictionaryWithObjectsAndKeys:
                                               [NSNumber numberWithInteger:relevantCount], MGWordCountKey,
@@ -277,6 +285,11 @@ NSString *MGWordCounterDidUpdateWordCountNotification = @"MGWordCounterDidUpdate
                                 dispatch_async(dispatch_get_main_queue(), ^{
                                     [self.delegate wordCounter:self updatedCount:_wordCount forSelection:NO];
                                 });
+                            }
+                            // Update Block
+                            if (self.counterUpdateBlock)
+                            {
+                                self.counterUpdateBlock(_wordCount,NO);
                             }
                             
                             // Send notification.

--- a/MGWordCounterDemo/MLGDocument.m
+++ b/MGWordCounterDemo/MLGDocument.m
@@ -44,6 +44,9 @@
     // Configure word-counter.
     wordCounter = [MGWordCounter wordCounterForTextView:self.textview];
     wordCounter.delegate = self;
+    wordCounter.counterUpdateBlock = ^(NSInteger count, BOOL selectionOnly){
+        //NSLog(@"Word count updated: %ld words (for %@)", (long)count, ((selectionOnly) ? @"selection" : @"full text"));
+    };
     self.textview.delegate = wordCounter;
     [wordCounter startCounting]; // Asynchronous; will return immediately and notify later.
 }

--- a/MGWordCounterDemoMobile/MLGViewController.m
+++ b/MGWordCounterDemoMobile/MLGViewController.m
@@ -26,6 +26,9 @@
     
     // Configure word-counter.
     wordCounter = [MGWordCounter wordCounterForTextView:self.textView];
+    wordCounter.counterUpdateBlock = ^(NSInteger count, BOOL selectionOnly){
+        //NSLog(@"Word count updated: %ld words (for %@)", (long)count, ((selectionOnly) ? @"selection" : @"full text"));
+    };
     wordCounter.delegate = self;
     self.textView.delegate = wordCounter;
     [wordCounter startCounting]; // Asynchronous; will return immediately and notify later.


### PR DESCRIPTION
You can set the property "counterUpdateBlock" to execute at the same point the delegate would get called.

I've also updated the demo code with an empty (commented out NSLog) block.
